### PR TITLE
fix(proto): improve path recovery after network change

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -5470,11 +5470,13 @@ impl Connection {
             }
             open_paths += 1;
 
+            // Read the network path BEFORE clearing local_ip, so the hint can
+            // check which interface the path was using.
+            let network_path = path.data.network_path;
+
             // Clear the local address for it to be obtained from the socket again. This applies to
             // all paths, regardless of being considered recoverable or not
             path.data.network_path.local_ip = None;
-
-            let network_path = path.data.network_path;
             let remote = network_path.remote;
 
             // Without multipath, the connection tries to recover the single path, whereas with

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -5570,6 +5570,20 @@ impl Connection {
             debug_assert!(!self.state.is_drained()); // required for endpoint_events, checked above
             self.endpoint_events
                 .push_back(EndpointEventInner::ResetToken(path_id, remote, reset_token));
+
+            // Reset the PTO backoff counter and re-arm loss detection. During the
+            // transport disconnect, PTO retransmits may have exhausted and the
+            // backoff grown exponentially (seconds/minutes). Resetting pto_count
+            // to 0 brings the PTO back to a reasonable duration so retransmits
+            // resume promptly once the transport recovers.
+            //
+            // We intentionally preserve the congestion controller and RTT estimate:
+            // for a truly recoverable path (e.g. relay reconnecting), these are
+            // still valid and resetting them would cause unnecessary slow-start.
+            if let Some(path) = self.paths.get_mut(&path_id) {
+                path.data.pto_count = 0;
+            }
+            self.set_loss_detection_timer(now, path_id);
         }
     }
 

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -850,6 +850,7 @@ impl Connection {
     /// Returns the previous value of the setting.
     pub fn set_path_max_idle_timeout(
         &mut self,
+        now: Instant,
         path_id: PathId,
         timeout: Option<Duration>,
     ) -> Result<Option<Duration>, ClosedPath> {
@@ -857,7 +858,18 @@ impl Connection {
             .paths
             .get_mut(&path_id)
             .ok_or(ClosedPath { _private: () })?;
-        Ok(std::mem::replace(&mut path.data.idle_timeout, timeout))
+        let prev = std::mem::replace(&mut path.data.idle_timeout, timeout);
+
+        // Re-arm the PathIdle timer if the new timeout is longer. Without this,
+        // an already-running timer continues with the old value until data is
+        // received. This matters when extending the timeout during a network
+        // change — the path may not receive data for a while (e.g. relay
+        // reconnecting), so the old timer would fire prematurely.
+        if !self.state.is_closed() {
+            self.reset_idle_timeout(now, self.highest_space, path_id);
+        }
+
+        Ok(prev)
     }
 
     /// Sets the keep_alive_interval for a specific path

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -860,11 +860,7 @@ impl Connection {
             .ok_or(ClosedPath { _private: () })?;
         let prev = std::mem::replace(&mut path.data.idle_timeout, timeout);
 
-        // Re-arm the PathIdle timer if the new timeout is longer. Without this,
-        // an already-running timer continues with the old value until data is
-        // received. This matters when extending the timeout during a network
-        // change — the path may not receive data for a while (e.g. relay
-        // reconnecting), so the old timer would fire prematurely.
+        // Re-arm the PathIdle timer with the new timeout.
         if !self.state.is_closed() {
             self.reset_idle_timeout(now, self.highest_space, path_id);
         }
@@ -5546,16 +5542,24 @@ impl Connection {
         /* RECOVERABLE PATHS */
 
         for (path_id, remote) in recoverable_paths.into_iter() {
-            let space = &mut self.spaces[SpaceId::Data];
-
             // Schedule a Ping for a liveness check.
-            if let Some(path_space) = space.number_spaces.get_mut(&path_id) {
+            if let Some(path_space) = self.spaces[SpaceId::Data]
+                .number_spaces
+                .get_mut(&path_id)
+            {
                 path_space.ping_pending = true;
 
                 if immediate_ack_allowed {
                     path_space.immediate_ack_pending = true;
                 }
             }
+
+            // Reset PTO backoff so retransmits resume promptly. Congestion controller
+            // and RTT are intentionally preserved for recoverable paths.
+            if let Some(path) = self.paths.get_mut(&path_id) {
+                path.data.pto_count = 0;
+            }
+            self.set_loss_detection_timer(now, path_id);
 
             let Some((reset_token, retired)) =
                 self.remote_cids.get_mut(&path_id).and_then(CidQueue::next)
@@ -5564,7 +5568,7 @@ impl Connection {
             };
 
             // Retire the current remote CID and any CIDs we had to skip.
-            space
+            self.spaces[SpaceId::Data]
                 .pending
                 .retire_cids
                 .extend(retired.map(|seq| (path_id, seq)));
@@ -5572,20 +5576,6 @@ impl Connection {
             debug_assert!(!self.state.is_drained()); // required for endpoint_events, checked above
             self.endpoint_events
                 .push_back(EndpointEventInner::ResetToken(path_id, remote, reset_token));
-
-            // Reset the PTO backoff counter and re-arm loss detection. During the
-            // transport disconnect, PTO retransmits may have exhausted and the
-            // backoff grown exponentially (seconds/minutes). Resetting pto_count
-            // to 0 brings the PTO back to a reasonable duration so retransmits
-            // resume promptly once the transport recovers.
-            //
-            // We intentionally preserve the congestion controller and RTT estimate:
-            // for a truly recoverable path (e.g. relay reconnecting), these are
-            // still valid and resetting them would cause unnecessary slow-start.
-            if let Some(path) = self.paths.get_mut(&path_id) {
-                path.data.pto_count = 0;
-            }
-            self.set_loss_detection_timer(now, path_id);
         }
     }
 

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -865,9 +865,11 @@ impl Connection {
             if let Some(new_timeout) = timeout {
                 let timer = Timer::PerPath(path_id, PathTimer::PathIdle);
                 let deadline = match (prev, self.timers.get(timer)) {
-                    (Some(old_timeout), Some(old_deadline)) => {
-                        (old_deadline - old_timeout + new_timeout).max(now)
-                    }
+                    (Some(old_timeout), Some(old_deadline)) => old_deadline
+                        .checked_sub(old_timeout)
+                        .map(|last_activity| last_activity + new_timeout)
+                        .unwrap_or(now + new_timeout)
+                        .max(now),
                     _ => now + new_timeout,
                 };
                 self.timers.set(timer, deadline, self.qlog.with_time(now));

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -860,10 +860,17 @@ impl Connection {
             .ok_or(ClosedPath { _private: () })?;
         let prev = std::mem::replace(&mut path.data.idle_timeout, timeout);
 
-        // Re-arm or stop the PathIdle timer.
+        // Adjust the PathIdle timer, accounting for already-elapsed idle time.
         if !self.state.is_closed() {
-            if timeout.is_some() {
-                self.reset_idle_timeout(now, self.highest_space, path_id);
+            if let Some(new_timeout) = timeout {
+                let timer = Timer::PerPath(path_id, PathTimer::PathIdle);
+                let deadline = match (prev, self.timers.get(timer)) {
+                    (Some(old_timeout), Some(old_deadline)) => {
+                        (old_deadline - old_timeout + new_timeout).max(now)
+                    }
+                    _ => now + new_timeout,
+                };
+                self.timers.set(timer, deadline, self.qlog.with_time(now));
             } else {
                 self.timers.stop(
                     Timer::PerPath(path_id, PathTimer::PathIdle),

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -5550,10 +5550,7 @@ impl Connection {
 
         for (path_id, remote) in recoverable_paths.into_iter() {
             // Schedule a Ping for a liveness check.
-            if let Some(path_space) = self.spaces[SpaceId::Data]
-                .number_spaces
-                .get_mut(&path_id)
-            {
+            if let Some(path_space) = self.spaces[SpaceId::Data].number_spaces.get_mut(&path_id) {
                 path_space.ping_pending = true;
 
                 if immediate_ack_allowed {

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -860,9 +860,16 @@ impl Connection {
             .ok_or(ClosedPath { _private: () })?;
         let prev = std::mem::replace(&mut path.data.idle_timeout, timeout);
 
-        // Re-arm the PathIdle timer with the new timeout.
+        // Re-arm or stop the PathIdle timer.
         if !self.state.is_closed() {
-            self.reset_idle_timeout(now, self.highest_space, path_id);
+            if timeout.is_some() {
+                self.reset_idle_timeout(now, self.highest_space, path_id);
+            } else {
+                self.timers.stop(
+                    Timer::PerPath(path_id, PathTimer::PathIdle),
+                    self.qlog.with_time(now),
+                );
+            }
         }
 
         Ok(prev)

--- a/noq-proto/src/connection/timer.rs
+++ b/noq-proto/src/connection/timer.rs
@@ -155,7 +155,6 @@ where
         self.heap.as_mut().and_then(|h| h.remove(key))
     }
 
-    #[cfg(test)]
     fn get(&self, key: &K) -> Option<&V> {
         for (k, v) in self.stack.iter().filter_map(|v| v.as_ref()) {
             if k == key {
@@ -240,6 +239,10 @@ impl PathTimerTable {
         self.timers[timer as usize] = Some(time);
     }
 
+    fn get(&self, timer: PathTimer) -> Option<Instant> {
+        self.timers[timer as usize]
+    }
+
     fn stop(&mut self, timer: PathTimer) {
         self.timers[timer as usize] = None;
     }
@@ -279,6 +282,13 @@ impl TimerTable {
             },
         }
         qlog.emit_timer_set(timer, time);
+    }
+
+    pub(super) fn get(&self, timer: Timer) -> Option<Instant> {
+        match timer {
+            Timer::Conn(timer) => self.generic[timer as usize],
+            Timer::PerPath(path_id, timer) => self.path_timers.get(&path_id)?.get(timer),
+        }
     }
 
     pub(super) fn set_or_stop(

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -564,8 +564,9 @@ impl ConnPair {
         path_id: PathId,
         timeout: Option<Duration>,
     ) -> Result<Option<Duration>, ClosedPath> {
+        let now = self.pair.time;
         self.conn_mut(side)
-            .set_path_max_idle_timeout(path_id, timeout)
+            .set_path_max_idle_timeout(now, path_id, timeout)
     }
 
     pub(super) fn set_path_keep_alive_interval(

--- a/noq/src/path.rs
+++ b/noq/src/path.rs
@@ -241,7 +241,8 @@ impl Path {
         timeout: Option<Duration>,
     ) -> Result<Option<Duration>, ClosedPath> {
         let mut state = self.conn.state.lock("path_set_max_idle_timeout");
-        state.inner.set_path_max_idle_timeout(self.id, timeout)
+        let now = state.runtime.now();
+        state.inner.set_path_max_idle_timeout(now, self.id, timeout)
     }
 
     /// Sets the keep_alive_interval for a specific path

--- a/noq/src/path.rs
+++ b/noq/src/path.rs
@@ -229,13 +229,13 @@ impl Path {
         )
     }
 
-    /// Sets the keep_alive_interval for a specific path
+    /// Sets the max idle timeout for a specific path
     ///
-    /// See [`TransportConfig::default_path_keep_alive_interval`] for details.
+    /// See [`TransportConfig::default_path_max_idle_timeout`] for details.
     ///
     /// Returns the previous value of the setting.
     ///
-    /// [`TransportConfig::default_path_keep_alive_interval`]: crate::TransportConfig::default_path_keep_alive_interval
+    /// [`TransportConfig::default_path_max_idle_timeout`]: crate::TransportConfig::default_path_max_idle_timeout
     pub fn set_max_idle_timeout(
         &self,
         timeout: Option<Duration>,


### PR DESCRIPTION
## Description

Three fixes for faster path recovery after network changes:

1. **Re-arm PathIdle timer when idle timeout is changed**: `set_path_max_idle_timeout` now immediately re-arms the PathIdle timer with the new value. Previously the running timer continued with the old deadline, causing relay paths to time out even when the timeout was extended during network changes.

2. **Reset PTO backoff for recoverable paths**: When `handle_network_change` marks a path as recoverable, reset `pto_count` to 0 and re-arm the loss detection timer. This ensures retransmissions resume promptly instead of waiting for the exponentially backed-off PTO from failed retransmits during the outage. Congestion controller and RTT estimates are preserved.

3. **Read network path before clearing local_ip**: `handle_network_change` cleared `local_ip` before the hint callback could check it, causing all paths to be marked recoverable regardless of interface state.

Relates to #376

## References

- [RFC 9002 §6.2 Computing PTO](https://datatracker.ietf.org/doc/html/rfc9002#section-6.2): PTO calculation uses `pto_count` for exponential backoff — resetting it restores base PTO timing
- [picoquic `nb_retransmit` reset in frames.c](https://github.com/private-octopus/picoquic/blob/master/picoquic/frames.c#L2777): picoquic resets retransmit count when an ACK proves the path works; we reset proactively on network change for recoverable paths

## Notes

- Only PTO count is reset, not congestion controller or RTT — for recoverable paths these learned values remain valid
- The PathIdle re-arm fix requires callers of `set_path_max_idle_timeout` to pass `now: Instant` (minor API change)
- The local_ip ordering fix ensures the hint callback sees the correct local_ip before it's cleared