### PR TITLE
fix(proto): prioritize ADD_ADDRESS frames before NEW_CONNECTION_ID

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -5984,11 +5984,7 @@ impl Connection {
                 .write_control_frames(builder, &mut space.pending, stats);
         }
 
-        // ADD_ADDRESS
-        // Prioritized before NEW_CONNECTION_ID: the remote can't use CIDs without
-        // knowing addresses to connect to. ADD_ADDRESS frames are small and critical
-        // for holepunching timing — a delayed ADD_ADDRESS means the remote can't
-        // probe our addresses even if it has CIDs.
+        // ADD_ADDRESS — before NEW_CONNECTION_ID so remote learns addresses first.
         while space_id == SpaceId::Data
             && !scheduling_info.is_abandoned
             && scheduling_info.may_send_data

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -5984,6 +5984,36 @@ impl Connection {
                 .write_control_frames(builder, &mut space.pending, stats);
         }
 
+        // ADD_ADDRESS
+        // Prioritized before NEW_CONNECTION_ID: the remote can't use CIDs without
+        // knowing addresses to connect to. ADD_ADDRESS frames are small and critical
+        // for holepunching timing — a delayed ADD_ADDRESS means the remote can't
+        // probe our addresses even if it has CIDs.
+        while space_id == SpaceId::Data
+            && !scheduling_info.is_abandoned
+            && scheduling_info.may_send_data
+            && frame::AddAddress::SIZE_BOUND <= builder.frame_space_remaining()
+        {
+            if let Some(added_address) = space.pending.add_address.pop_last() {
+                builder.write_frame(added_address, stats);
+            } else {
+                break;
+            }
+        }
+
+        // REMOVE_ADDRESS
+        while space_id == SpaceId::Data
+            && !scheduling_info.is_abandoned
+            && scheduling_info.may_send_data
+            && frame::RemoveAddress::SIZE_BOUND <= builder.frame_space_remaining()
+        {
+            if let Some(removed_address) = space.pending.remove_address.pop_last() {
+                builder.write_frame(removed_address, stats);
+            } else {
+                break;
+            }
+        }
+
         // NEW_CONNECTION_ID
         let cid_len = self
             .local_cid_state
@@ -6103,32 +6133,6 @@ impl Connection {
         {
             self.streams
                 .write_stream_frames(builder, self.config.send_fairness, stats);
-        }
-
-        // ADD_ADDRESS
-        while space_id == SpaceId::Data
-            && !scheduling_info.is_abandoned
-            && scheduling_info.may_send_data
-            && frame::AddAddress::SIZE_BOUND <= builder.frame_space_remaining()
-        {
-            if let Some(added_address) = space.pending.add_address.pop_last() {
-                builder.write_frame(added_address, stats);
-            } else {
-                break;
-            }
-        }
-
-        // REMOVE_ADDRESS
-        while space_id == SpaceId::Data
-            && !scheduling_info.is_abandoned
-            && scheduling_info.may_send_data
-            && frame::RemoveAddress::SIZE_BOUND <= builder.frame_space_remaining()
-        {
-            if let Some(removed_address) = space.pending.remove_address.pop_last() {
-                builder.write_frame(removed_address, stats);
-            } else {
-                break;
-            }
         }
     }
 

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -705,18 +705,7 @@ fn per_path_observed_address() -> TestResult {
     Ok(())
 }
 
-/// ADD_ADDRESS frames must be sent in the first data packet, not delayed behind
-/// bulk PATH_NEW_CONNECTION_ID frames.
-///
-/// Regression test: the server adds both its public and private IP to NAT traversal
-/// before the first data packet. Both ADD_ADDRESS frames should be sent immediately.
-/// Previously, ADD_ADDRESS was scheduled after NEW_CONNECTION_ID, so 35+ CID frames
-/// could fill the packet and push ADD_ADDRESS to a later packet (10+ seconds later
-/// with pacing under load).
-///
-/// draft-seemann-quic-nat-traversal-02: ADD_ADDRESS frames advertise addresses for
-/// NAT traversal. The client can't probe addresses it doesn't know about, so delays
-/// directly impact holepunching success.
+/// Regression: ADD_ADDRESS frames must not be delayed behind bulk CID frames.
 #[test]
 fn add_address_not_delayed_by_cid_frames() -> TestResult {
     let _guard = subscribe();
@@ -742,13 +731,11 @@ fn add_address_not_delayed_by_cid_frames() -> TestResult {
     // Record frame stats before driving
     let stats_before = pair.stats(Server);
 
-    // Drive just the server to send ONE round of packets
+    // Drive the server to produce its next burst of packets
     pair.drive_server();
 
     let stats_after = pair.stats(Server);
 
-    // Both ADD_ADDRESS frames should have been sent in the first burst.
-    // Previously only 1 would fit because CID frames consumed all packet space.
     let add_addr_sent = stats_after.frame_tx.add_address - stats_before.frame_tx.add_address;
     assert_eq!(
         add_addr_sent, 2,

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -705,6 +705,59 @@ fn per_path_observed_address() -> TestResult {
     Ok(())
 }
 
+/// ADD_ADDRESS frames must be sent in the first data packet, not delayed behind
+/// bulk PATH_NEW_CONNECTION_ID frames.
+///
+/// Regression test: the server adds both its public and private IP to NAT traversal
+/// before the first data packet. Both ADD_ADDRESS frames should be sent immediately.
+/// Previously, ADD_ADDRESS was scheduled after NEW_CONNECTION_ID, so 35+ CID frames
+/// could fill the packet and push ADD_ADDRESS to a later packet (10+ seconds later
+/// with pacing under load).
+///
+/// draft-seemann-quic-nat-traversal-02: ADD_ADDRESS frames advertise addresses for
+/// NAT traversal. The client can't probe addresses it doesn't know about, so delays
+/// directly impact holepunching success.
+#[test]
+fn add_address_not_delayed_by_cid_frames() -> TestResult {
+    let _guard = subscribe();
+
+    let mut cfg = TransportConfig::default();
+    cfg.max_concurrent_multipath_paths(12); // high path count = many CID frames
+    cfg.initial_rtt(Duration::from_millis(10));
+    cfg.set_max_remote_nat_traversal_addresses(12); // enable NAT traversal
+
+    let mut pair = ConnPair::with_transport_cfg(cfg.clone(), cfg);
+    pair.drive();
+
+    // Drain handshake events
+    while pair.poll(Client).is_some() {}
+    while pair.poll(Server).is_some() {}
+
+    // Server adds two NAT traversal addresses (simulating public + private IP)
+    let addr1: SocketAddr = "10.0.0.1:1234".parse().unwrap();
+    let addr2: SocketAddr = "203.0.113.1:1234".parse().unwrap();
+    pair.add_nat_traversal_address(Server, addr1)?;
+    pair.add_nat_traversal_address(Server, addr2)?;
+
+    // Record frame stats before driving
+    let stats_before = pair.stats(Server);
+
+    // Drive just the server to send ONE round of packets
+    pair.drive_server();
+
+    let stats_after = pair.stats(Server);
+
+    // Both ADD_ADDRESS frames should have been sent in the first burst.
+    // Previously only 1 would fit because CID frames consumed all packet space.
+    let add_addr_sent = stats_after.frame_tx.add_address - stats_before.frame_tx.add_address;
+    assert_eq!(
+        add_addr_sent, 2,
+        "both ADD_ADDRESS frames should be sent immediately, not delayed behind CID frames"
+    );
+
+    Ok(())
+}
+
 #[test]
 fn mtud_on_two_paths() -> TestResult {
     let _guard = subscribe();


### PR DESCRIPTION
## Description

Move ADD_ADDRESS frame scheduling before NEW_CONNECTION_ID in `populate_packet`. Previously, 35+ CID frames could fill the first data packet and push ADD_ADDRESS to a later packet (10+ seconds later with pacing under load). The client can't probe addresses it doesn't know about, so this directly delayed holepunching.

Relates to #376

## References

- [draft-seemann-quic-nat-traversal-02 §3](https://datatracker.ietf.org/doc/html/draft-seemann-quic-nat-traversal-02#section-3): ADD_ADDRESS frames advertise addresses for NAT traversal — timely delivery is critical for holepunch success