### PR TITLE
feat(noq-proto): preserve insertion order for QNT addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1878,6 +1878,7 @@ dependencies = [
  "getrandom 0.4.2",
  "hex-literal",
  "identity-hash",
+ "indexmap",
  "lru-slab",
  "n0-qlog",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ getrandom = { version = "0.4", default-features = false }
 hdrhistogram = { version = "7.2", default-features = false }
 hex-literal = "0.4"
 identity-hash = "0.1.0"
+indexmap = "2"
 log = "0.4"
 lru-slab = "0.1.2"
 pin-project-lite = "0.2"

--- a/noq-proto/Cargo.toml
+++ b/noq-proto/Cargo.toml
@@ -61,6 +61,7 @@ derive_more = { workspace = true }
 enum-assoc = { workspace = true }
 fastbloom = { workspace = true, optional = true }
 identity-hash = { workspace = true }
+indexmap = { workspace = true }
 lru-slab = { workspace = true }
 qlog = { workspace = true, optional = true }
 rand = { workspace = true }

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -6883,8 +6883,9 @@ impl Connection {
     pub fn add_nat_traversal_address(
         &mut self,
         address: SocketAddr,
+        priority: u8,
     ) -> Result<(), n0_nat_traversal::Error> {
-        if let Some(added) = self.n0_nat_traversal.add_local_address(address)? {
+        if let Some(added) = self.n0_nat_traversal.add_local_address(address, priority)? {
             self.spaces[SpaceId::Data].pending.add_address.insert(added);
         };
         Ok(())

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -35,7 +35,7 @@ use crate::{
         self, Close, DataBlocked, Datagram, FrameStruct, NewToken, ObservedAddr, StreamDataBlocked,
         StreamsBlocked,
     },
-    n0_nat_traversal,
+    n0_nat_traversal::{self, FxIndexSet},
     packet::{
         FixedLengthConnectionIdParser, Header, InitialHeader, InitialPacket, LongType, Packet,
         PacketNumber, PartialDecode, SpaceId,
@@ -5993,7 +5993,7 @@ impl Connection {
             && let Some((round, addresses)) = space.pending.reach_out.as_mut()
         {
             while let Some(local_addr) = addresses.iter().next().copied() {
-                let local_addr = addresses.take(&local_addr).expect("found from iter");
+                let local_addr = addresses.shift_take(&local_addr).expect("found from iter");
                 let reach_out = frame::ReachOut::new(*round, local_addr);
                 if builder.frame_space_remaining() > reach_out.size() {
                     builder.write_frame(reach_out, stats);
@@ -7521,7 +7521,7 @@ impl SentFrames {
                 let (recorded_round, reach_outs) = self
                     .retransmits_mut()
                     .reach_out
-                    .get_or_insert_with(|| (round, FxHashSet::default()));
+                    .get_or_insert_with(|| (round, FxIndexSet::default()));
                 // Only record reach outs for the current round or a newer than the recorded one.
                 if *recorded_round == round {
                     // Same round, simply append.
@@ -7529,7 +7529,7 @@ impl SentFrames {
                 } else if *recorded_round < round {
                     // New round.
                     *recorded_round = round;
-                    reach_outs.drain();
+                    reach_outs.clear();
                     reach_outs.insert((ip, port));
                 } else {
                     // ignore old reach out that was sent

--- a/noq-proto/src/connection/send_buffer.rs
+++ b/noq-proto/src/connection/send_buffer.rs
@@ -585,9 +585,9 @@ mod tests {
 mod proptests {
     use super::*;
 
+    use crate::tests::subscribe;
     use proptest::prelude::*;
     use test_strategy::{Arbitrary, proptest};
-    use crate::tests::subscribe;
     use tracing::trace;
 
     #[derive(Debug, Clone, Arbitrary)]

--- a/noq-proto/src/connection/spaces.rs
+++ b/noq-proto/src/connection/spaces.rs
@@ -8,6 +8,8 @@ use std::{
 
 use rand::{CryptoRng, RngExt};
 use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::n0_nat_traversal::FxIndexSet;
 use sorted_index_buffer::SortedIndexBuffer;
 use tracing::trace;
 
@@ -544,8 +546,8 @@ pub struct Retransmits {
     pub(super) add_address: BTreeSet<AddAddress>,
     /// Address IDs to remove in `REMOVE_ADDRESS` frames
     pub(super) remove_address: BTreeSet<RemoveAddress>,
-    /// Round and local addresses to advertise in `REACH_OUT` frames
-    pub(super) reach_out: Option<(VarInt, FxHashSet<(IpAddr, u16)>)>,
+    /// Round and local addresses to advertise in `REACH_OUT` frames, in priority order.
+    pub(super) reach_out: Option<(VarInt, FxIndexSet<(IpAddr, u16)>)>,
 }
 
 impl Retransmits {

--- a/noq-proto/src/n0_nat_traversal.rs
+++ b/noq-proto/src/n0_nat_traversal.rs
@@ -92,8 +92,8 @@ pub(crate) struct ClientState {
     /// These are indexed by their advertised Id. For each address, whether the address should be
     /// reported in nat traversal continuations is kept.
     remote_addresses: FxHashMap<VarInt, (IpPort, bool)>,
-    /// Local candidate addresses, in insertion order.
-    local_addresses: FxIndexSet<IpPort>,
+    /// Local candidate addresses with their priority (lower = more important).
+    local_addresses: FxHashMap<IpPort, u8>,
     /// Current nat traversal round.
     round: VarInt,
     /// [`PathId`]s used to probe remotes assigned to this round.
@@ -112,21 +112,19 @@ impl ClientState {
         }
     }
 
-    fn add_local_address(&mut self, address: IpPort) -> Result<(), Error> {
+    fn add_local_address(&mut self, address: IpPort, priority: u8) -> Result<(), Error> {
         if self.local_addresses.len() < self.max_local_addresses {
-            self.local_addresses.insert(address);
+            self.local_addresses.insert(address, priority);
             Ok(())
-        } else if self.local_addresses.contains(&address) {
-            // at capacity, but the address is known, no issues here
+        } else if self.local_addresses.contains_key(&address) {
             Ok(())
         } else {
-            // at capacity and the address is new
             Err(Error::TooManyAddresses)
         }
     }
 
     fn remove_local_address(&mut self, address: &IpPort) {
-        self.local_addresses.shift_remove(address);
+        self.local_addresses.remove(address);
     }
 
     /// Initiates a new nat traversal round.
@@ -163,7 +161,7 @@ impl ClientState {
 
         Ok(NatTraversalRound {
             new_round: self.round,
-            reach_out_at: self.local_addresses.iter().copied().collect(),
+            reach_out_at: sorted_by_priority(&self.local_addresses),
             addresses_to_probe,
             prev_round_path_ids,
         })
@@ -483,12 +481,13 @@ impl State {
     pub(crate) fn add_local_address(
         &mut self,
         address: SocketAddr,
+        priority: u8,
     ) -> Result<Option<AddAddress>, Error> {
         let ip_port = IpPort::from((address.ip(), address.port()));
         match self {
             Self::NotNegotiated => Err(Error::ExtensionNotNegotiated),
             Self::ClientSide(client_state) => {
-                client_state.add_local_address(ip_port)?;
+                client_state.add_local_address(ip_port, priority)?;
                 Ok(None)
             }
             Self::ServerSide(server_state) => server_state.add_local_address(ip_port),
@@ -521,9 +520,8 @@ impl State {
             Self::NotNegotiated => Err(Error::ExtensionNotNegotiated),
             Self::ClientSide(client_state) => Ok(client_state
                 .local_addresses
-                .iter()
-                .copied()
-                .map(Into::into)
+                .keys()
+                .map(|addr| SocketAddr::from(*addr))
                 .collect()),
             Self::ServerSide(server_state) => Ok(server_state
                 .local_addresses
@@ -539,6 +537,13 @@ impl State {
 ///
 /// This checks that the address family is supported by our local socket.
 /// If it is supported, then the address is mapped to the respective IP address.
+/// Returns addresses sorted by priority (lower = first).
+fn sorted_by_priority(addrs: &FxHashMap<IpPort, u8>) -> FxIndexSet<IpPort> {
+    let mut set: FxIndexSet<IpPort> = addrs.keys().copied().collect();
+    set.sort_by(|a, b| addrs[a].cmp(&addrs[b]));
+    set
+}
+
 /// If the given address is an IPv6 address, but our local socket doesn't support
 /// IPv6, then this returns `None`.
 pub(crate) fn map_to_local_socket_family(address: IpAddr, ipv6: bool) -> Option<IpAddr> {
@@ -681,21 +686,26 @@ mod tests {
     }
 
     #[test]
-    fn client_reach_out_in_insertion_order() {
+    fn client_reach_out_sorted_by_priority() {
         let mut state = ClientState::new(10, 10);
 
-        // Deliberately not sorted by IP.
-        let addrs: Vec<SocketAddr> = vec![
-            "203.0.113.5:4000".parse().unwrap(),
-            "10.0.0.1:3000".parse().unwrap(),
-            "192.168.1.1:5000".parse().unwrap(),
-            "172.17.0.1:6000".parse().unwrap(),
-            "8.8.8.8:7000".parse().unwrap(),
-        ];
-
-        for addr in &addrs {
-            state.add_local_address((addr.ip(), addr.port())).unwrap();
-        }
+        // Add addresses with priorities in non-sorted IP order.
+        // Priority 0 = most important, should appear first in REACH_OUT.
+        state
+            .add_local_address(("10.0.0.1".parse().unwrap(), 3000), 3)
+            .unwrap();
+        state
+            .add_local_address(("203.0.113.5".parse().unwrap(), 4000), 0)
+            .unwrap();
+        state
+            .add_local_address(("172.17.0.1".parse().unwrap(), 6000), 2)
+            .unwrap();
+        state
+            .add_local_address(("8.8.8.8".parse().unwrap(), 7000), 1)
+            .unwrap();
+        state
+            .add_local_address(("192.168.1.1".parse().unwrap(), 5000), 4)
+            .unwrap();
 
         let round = state.initiate_nat_traversal_round(false).unwrap();
         let reach_out: Vec<SocketAddr> = round
@@ -704,6 +714,15 @@ mod tests {
             .map(SocketAddr::from)
             .collect();
 
-        assert_eq!(reach_out, addrs);
+        assert_eq!(
+            reach_out,
+            vec![
+                "203.0.113.5:4000".parse::<SocketAddr>().unwrap(),
+                "8.8.8.8:7000".parse().unwrap(),
+                "172.17.0.1:6000".parse().unwrap(),
+                "10.0.0.1:3000".parse().unwrap(),
+                "192.168.1.1:5000".parse().unwrap(),
+            ]
+        );
     }
 }

--- a/noq-proto/src/n0_nat_traversal.rs
+++ b/noq-proto/src/n0_nat_traversal.rs
@@ -5,7 +5,11 @@ use std::{
     net::{IpAddr, SocketAddr},
 };
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use indexmap::{IndexMap, IndexSet};
+use rustc_hash::{FxBuildHasher, FxHashMap};
+
+pub(crate) type FxIndexSet<T> = IndexSet<T, FxBuildHasher>;
+pub(crate) type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;
 use tracing::trace;
 
 use crate::{
@@ -41,8 +45,8 @@ pub enum Error {
 pub(crate) struct NatTraversalRound {
     /// Sequence number to use for the new reach out frames.
     pub(crate) new_round: VarInt,
-    /// Addresses to use to send reach out frames.
-    pub(crate) reach_out_at: FxHashSet<IpPort>,
+    /// Addresses to send in REACH_OUT frames, in priority order.
+    pub(crate) reach_out_at: FxIndexSet<IpPort>,
     /// Remotes to probe by attempting to open new paths.
     ///
     /// The addresses include their Id, so that it can be used to signal these should be returned
@@ -88,9 +92,8 @@ pub(crate) struct ClientState {
     /// These are indexed by their advertised Id. For each address, whether the address should be
     /// reported in nat traversal continuations is kept.
     remote_addresses: FxHashMap<VarInt, (IpPort, bool)>,
-    /// Candidate addresses the local client reports as potentially reachable, to use for nat
-    /// traversal attempts.
-    local_addresses: FxHashSet<IpPort>,
+    /// Local candidate addresses, in insertion order.
+    local_addresses: FxIndexSet<IpPort>,
     /// Current nat traversal round.
     round: VarInt,
     /// [`PathId`]s used to probe remotes assigned to this round.
@@ -123,7 +126,7 @@ impl ClientState {
     }
 
     fn remove_local_address(&mut self, address: &IpPort) {
-        self.local_addresses.remove(address);
+        self.local_addresses.shift_remove(address);
     }
 
     /// Initiates a new nat traversal round.
@@ -313,10 +316,10 @@ pub(crate) struct ServerState {
     /// Servers keep track of the client's most recent round and cancel probing related to previous
     /// rounds.
     round: VarInt,
-    /// Addresses to which PATH_CHALLENGES need to be sent, with their probe state.
+    /// Addresses to probe via PATH_CHALLENGE, in insertion order.
     ///
-    /// Probes are retransmitted up to [`MAX_OFF_PATH_PROBE_ATTEMPTS`] times.
-    pending_probes: FxHashMap<IpPort, ProbeState>,
+    /// Retransmitted up to [`MAX_OFF_PATH_PROBE_ATTEMPTS`] times.
+    pending_probes: FxIndexMap<IpPort, ProbeState>,
 }
 
 impl ServerState {
@@ -640,5 +643,67 @@ mod tests {
             map_to_local_socket_family("::ffff:1.1.1.1".parse().unwrap(), false),
             Some("1.1.1.1".parse().unwrap())
         )
+    }
+
+    #[test]
+    fn server_probes_in_insertion_order() {
+        let mut state = ServerState::new(10, 10);
+
+        // Deliberately not sorted by IP to catch ordering bugs.
+        let addrs: Vec<SocketAddr> = vec![
+            "203.0.113.5:4000".parse().unwrap(),
+            "10.0.0.1:3000".parse().unwrap(),
+            "192.168.1.1:5000".parse().unwrap(),
+            "172.17.0.1:6000".parse().unwrap(),
+            "8.8.8.8:7000".parse().unwrap(),
+        ];
+
+        for addr in &addrs {
+            state
+                .handle_reach_out(
+                    ReachOut {
+                        round: 1u32.into(),
+                        ip: addr.ip(),
+                        port: addr.port(),
+                    },
+                    false,
+                )
+                .unwrap();
+        }
+
+        let mut probe_order = Vec::new();
+        while let Some(addr) = state.next_probe_addr() {
+            probe_order.push(addr);
+            state.mark_probe_sent((addr.ip(), addr.port()));
+        }
+
+        assert_eq!(probe_order, addrs);
+    }
+
+    #[test]
+    fn client_reach_out_in_insertion_order() {
+        let mut state = ClientState::new(10, 10);
+
+        // Deliberately not sorted by IP.
+        let addrs: Vec<SocketAddr> = vec![
+            "203.0.113.5:4000".parse().unwrap(),
+            "10.0.0.1:3000".parse().unwrap(),
+            "192.168.1.1:5000".parse().unwrap(),
+            "172.17.0.1:6000".parse().unwrap(),
+            "8.8.8.8:7000".parse().unwrap(),
+        ];
+
+        for addr in &addrs {
+            state.add_local_address((addr.ip(), addr.port())).unwrap();
+        }
+
+        let round = state.initiate_nat_traversal_round(false).unwrap();
+        let reach_out: Vec<SocketAddr> = round
+            .reach_out_at
+            .into_iter()
+            .map(SocketAddr::from)
+            .collect();
+
+        assert_eq!(reach_out, addrs);
     }
 }

--- a/noq-proto/src/tests/encode_decode.rs
+++ b/noq-proto/src/tests/encode_decode.rs
@@ -1,6 +1,6 @@
 use bytes::{BufMut, BytesMut};
+use proptest::{prelude::*, prop_assert_ne};
 use test_strategy::proptest;
-use proptest::{prop_assert_ne, prelude::*};
 
 use crate::{
     FrameType,

--- a/noq-proto/src/tests/random_interaction.rs
+++ b/noq-proto/src/tests/random_interaction.rs
@@ -228,7 +228,7 @@ impl TestOp {
                     Side::Server => server,
                 };
                 let conn = state.conn(pair)?;
-                conn.add_nat_traversal_address(address)
+                conn.add_nat_traversal_address(address, 0)
                     .inspect_err(|err| error!(?err, "AddHpAddr failed"))
                     .ok();
             }

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -745,7 +745,7 @@ impl ConnPair {
         side: Side,
         address: SocketAddr,
     ) -> Result<(), n0_nat_traversal::Error> {
-        self.conn_mut(side).add_nat_traversal_address(address)
+        self.conn_mut(side).add_nat_traversal_address(address, 0)
     }
 
     pub(super) fn remove_nat_traversal_address(

--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -925,9 +925,10 @@ impl Connection {
     pub fn add_nat_traversal_address(
         &self,
         address: SocketAddr,
+        priority: u8,
     ) -> Result<(), n0_nat_traversal::Error> {
         let mut conn = self.0.lock_and_wake("add_nat_traversal_addresses");
-        conn.inner.add_nat_traversal_address(address)
+        conn.inner.add_nat_traversal_address(address, priority)
     }
 
     /// Removes one or more addresses from the set of addresses at which this endpoint is reachable

--- a/noq/src/tests.rs
+++ b/noq/src/tests.rs
@@ -1454,7 +1454,9 @@ async fn nat_traversal_wakes_connection_driver() -> TestResult {
 
         // Server adds its address — this queues an ADD_ADDRESS frame.
         // Without wake(), this frame won't be sent until a timer fires.
-        server_conn.add_nat_traversal_address(server_addr).unwrap();
+        server_conn
+            .add_nat_traversal_address(server_addr, 0)
+            .unwrap();
 
         // The client should learn the server's address within 500ms.
         let result = tokio::time::timeout(Duration::from_millis(500), async {


### PR DESCRIPTION
Given the potentially limits of probes we can do, we want to do them in the order the user tells them about.