### PR TITLE
feat(proto): Add `{Connection,Path}Stats::sent_{packets,bytes}`

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -1820,8 +1820,6 @@ impl Connection {
 
         builder.finish_and_track(now, self, path_id, PadDatagram::ToSize(probe_size));
 
-        self.path_stats.get_mut(path_id).sent_plpmtud_probes += 1;
-
         Some(self.build_transmit(path_id, transmit))
     }
 

--- a/noq-proto/src/connection/packet_builder.rs
+++ b/noq-proto/src/connection/packet_builder.rs
@@ -286,6 +286,20 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
             false => 0,
         };
 
+        // `lost_packets` is not incremented for MTUD probes, so we avoid incrementing
+        // `sent_packets` for it as well.
+        if conn.path_data(path_id).mtud.in_flight_mtu_probe() == Some(packet_number) {
+            conn.path_stats.get_mut(path_id).sent_plpmtud_probes += 1;
+        } else {
+            // Needs to be incremented in the same place that constructs `SentPacket`s,
+            // to ensure it matches `lost_packets` (`lost_packets <= sent_packets`).
+            // Similarly, `sent_bytes` needs to match how `lost_bytes` are incremented.
+            // Hence, the weird case of sent_packets increasing, but sent_bytes not,
+            // because the `size` above is what makes it into `lost_bytes` eventually.
+            conn.path_stats.get_mut(path_id).sent_packets += 1;
+            conn.path_stats.get_mut(path_id).sent_bytes += size as u64;
+        }
+
         let packet = SentPacket {
             path_generation: conn.paths.get_mut(&path_id).unwrap().data.generation(),
             largest_acked: sent.largest_acked,

--- a/noq-proto/src/connection/stats.rs
+++ b/noq-proto/src/connection/stats.rs
@@ -232,6 +232,29 @@ pub struct PathStats {
     pub congestion_events: u64,
     /// Spurious congestion events on the connection.
     pub spurious_congestion_events: u64,
+    /// The number of QUIC packets sent on this path.
+    ///
+    /// The intention for this stat is to capture all the packets we send that are congestion controlled
+    /// and which we *expect to be transmitted*.
+    ///
+    /// This does *not* count off-path path challenges, off-path path responses, any path challenges
+    /// or responses sent for NAT traversal or MTUD probes, for which the above is not the case (we
+    /// expect these packets to not make it in many cases).
+    ///
+    /// This value should be meaningful relative to [`Self::lost_packets`], packets this way can get lost
+    /// and will be counted in lost packets.
+    ///
+    /// This counts individual QUIC packets, which may differ from [`UdpStats::datagrams`] when
+    /// packets are coalesced into a single UDP datagram.
+    pub sent_packets: u64,
+    /// The total number of QUIC bytes sent on this path (sum of all sent packet sizes).
+    ///
+    /// This counts only the QUIC packet payload bytes, not UDP/IP header bytes.
+    ///
+    /// This also does not count coalesced packets.
+    ///
+    /// Caveats similar to the ones in [`Self::sent_packets`] apply.
+    pub sent_bytes: u64,
     /// The number of packets lost on this path.
     pub lost_packets: u64,
     /// The number of bytes lost on this path.
@@ -265,6 +288,14 @@ pub struct ConnectionStats {
     pub frame_tx: FrameStats,
     /// Statistics about frames received on the connection.
     pub frame_rx: FrameStats,
+    /// The number of QUIC packets sent on the connection (sum across all paths).
+    ///
+    /// See also [`PathStats::sent_packets`].
+    pub sent_packets: u64,
+    /// The total number of QUIC bytes sent on the connection (sum across all paths).
+    ///
+    /// See also [`PathStats::sent_bytes`].
+    pub sent_bytes: u64,
     /// The number of packets lost on the connection.
     pub lost_packets: u64,
     /// The number of bytes lost on the connection.
@@ -290,6 +321,8 @@ impl std::ops::Add<PathStats> for ConnectionStats {
             cwnd: _,
             congestion_events: _,
             spurious_congestion_events: _,
+            sent_packets,
+            sent_bytes,
             lost_packets,
             lost_bytes,
             sent_plpmtud_probes: _,
@@ -302,6 +335,8 @@ impl std::ops::Add<PathStats> for ConnectionStats {
             udp_rx: self.udp_rx + udp_rx,
             frame_tx: self.frame_tx + frame_tx,
             frame_rx: self.frame_rx + frame_rx,
+            sent_packets: self.sent_packets + sent_packets,
+            sent_bytes: self.sent_bytes + sent_bytes,
             lost_packets: self.lost_packets + lost_packets,
             lost_bytes: self.lost_bytes + lost_bytes,
             #[cfg(test)]
@@ -323,6 +358,8 @@ impl std::ops::AddAssign<PathStats> for ConnectionStats {
             cwnd: _,
             congestion_events: _,
             spurious_congestion_events: _,
+            sent_packets: path_sent_packets,
+            sent_bytes: path_sent_bytes,
             lost_packets: path_lost_packets,
             lost_bytes: path_lost_bytes,
             sent_plpmtud_probes: _,
@@ -335,6 +372,8 @@ impl std::ops::AddAssign<PathStats> for ConnectionStats {
             udp_rx,
             frame_tx,
             frame_rx,
+            sent_packets,
+            sent_bytes,
             lost_packets,
             lost_bytes,
             #[cfg(test)]
@@ -344,6 +383,8 @@ impl std::ops::AddAssign<PathStats> for ConnectionStats {
         *udp_rx += path_udp_rx;
         *frame_tx += path_frame_tx;
         *frame_rx += path_frame_rx;
+        *sent_packets += path_sent_packets;
+        *sent_bytes += path_sent_bytes;
         *lost_packets += path_lost_packets;
         *lost_bytes += path_lost_bytes;
     }

--- a/noq-proto/src/connection/stats.rs
+++ b/noq-proto/src/connection/stats.rs
@@ -235,7 +235,7 @@ pub struct PathStats {
     /// The number of QUIC packets sent on this path.
     ///
     /// The intention for this stat is to capture all the packets we send that are congestion controlled
-    /// and which we *expect to be transmitted*.
+    /// and which we *expect to be received*.
     ///
     /// This does *not* count off-path path challenges, off-path path responses, any path challenges
     /// or responses sent for NAT traversal or MTUD probes, for which the above is not the case (we
@@ -250,8 +250,11 @@ pub struct PathStats {
     /// The total number of QUIC bytes sent on this path (sum of all sent packet sizes).
     ///
     /// This counts only the QUIC packet payload bytes, not UDP/IP header bytes.
+    /// It also doesn't count ACK-only packets in an effort to stay consistent with
+    /// [`Self::lost_bytes`], which doesn't count ACK-only packets either.
     ///
-    /// This also does not count coalesced packets.
+    /// If you're interested in the full amount of bytes transmitted, consider looking
+    /// at [`ConnectionStats::udp_tx`].
     ///
     /// Caveats similar to the ones in [`Self::sent_packets`] apply.
     pub sent_bytes: u64,
@@ -290,11 +293,13 @@ pub struct ConnectionStats {
     pub frame_rx: FrameStats,
     /// The number of QUIC packets sent on the connection (sum across all paths).
     ///
-    /// See also [`PathStats::sent_packets`].
+    /// This does not count bytes for some kinds of probing packets, for more information
+    /// see [`PathStats::sent_packets`].
     pub sent_packets: u64,
     /// The total number of QUIC bytes sent on the connection (sum across all paths).
     ///
-    /// See also [`PathStats::sent_bytes`].
+    /// This does not count bytes for some kinds of probing packets, for more information
+    /// see [`PathStats::sent_bytes`] and [`PathStats::sent_packets`].
     pub sent_bytes: u64,
     /// The number of packets lost on the connection.
     pub lost_packets: u64,

--- a/noq-proto/src/connection/stats.rs
+++ b/noq-proto/src/connection/stats.rs
@@ -238,8 +238,8 @@ pub struct PathStats {
     /// and which we *expect to be received*.
     ///
     /// This does *not* count off-path path challenges, off-path path responses, any path challenges
-    /// or responses sent for NAT traversal or MTUD probes, for which the above is not the case (we
-    /// expect these packets to not make it in many cases).
+    /// or responses sent for NAT traversal or MTUD probes (we expect these packets to not make it in
+    /// many cases).
     ///
     /// This value should be meaningful relative to [`Self::lost_packets`], packets this way can get lost
     /// and will be counted in lost packets.

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -4515,3 +4515,27 @@ fn initial_tail_loss_probe() {
     pair.drive();
     pair.server.assert_accept();
 }
+
+/// Snapshot test to prevent accidentally skipping code-paths related to `sent_packets` stats.
+#[test]
+fn sent_packets_stats_snapshot_test() {
+    let _guard = subscribe();
+    let mut pair = Pair::default();
+    let (client_ch, server_ch) = pair.connect();
+    pair.drive();
+
+    let client_stats = pair.client_conn_mut(client_ch).stats();
+    let server_stats = pair.server_conn_mut(server_ch).stats();
+    assert_eq!(client_stats.sent_packets, 9);
+    assert_eq!(server_stats.sent_packets, 6);
+
+    let s = pair.client_streams(client_ch).open(Dir::Uni).unwrap();
+    const MSG: &[u8] = b"Hello, World!";
+    pair.client_send(client_ch, s).write(MSG).unwrap();
+    pair.drive();
+
+    let client_stats2 = pair.client_conn_mut(client_ch).stats();
+    let server_stats2 = pair.server_conn_mut(server_ch).stats();
+    assert_eq!(client_stats2.sent_packets, 10);
+    assert_eq!(server_stats2.sent_packets, 7);
+}


### PR DESCRIPTION
## Description

Closes #565 

## Breaking Changes

Only additions:
- Adds `ConnectionStats::sent_packets`, `ConnectionStats::sent_bytes`, `PathStats::sent_packets`, `PathStast::sent_bytes`

## Notes & open questions

The guiding principle behind this PR is a central use case of continually monitoring `sent_packets` and `lost_packets` as an indicator of "how good" our connection (or path) is doing and how healthy it is.

Previously, this was not possible, because `lost_packets` can't really be seen relative to `UdpStats::datagrams` due to coalescing and generally some other inconsistencies.

In this PR I'm taking great care to make sure `sent_packets` matches `lost_packets` once every single packet gets lost, and maintaining the invariant that `lost_packets <= sent_packets` always (I had added a `debug_assert!` for this at some point, not sure if people would prefer adding that back?).
~~Also, `lost_packets` only counts packets that we had "expected to make it", but got lost. I.e. it does *not* count off-path/NAT traversal challenges and responses nor MTUD probes.
I'm matching this behavior with `sent_packets` now.~~
We decided against this after some discussion. `sent_packets` is just what it says - the packets sent, regardless whether those are probes or sent on a path that we expect to be alive.

Detecting if the current packet is an MTUD probe is somewhat ugly... I decided to use `conn.path_data(path_id).mtud.in_flight_mtu_probe() == Some(packet_number)` for this, but could also have matched on `PadDatagram::ToSize`, as that's only used by MTUD probes, but the former seemed clearer.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
