### PR TITLE
fix(noq): resolve pending OpenPath on connection termination

### DIFF
--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -1805,6 +1805,15 @@ impl State {
         }
         shared.handshake_confirmed.notify_waiters();
         wake_all_notify(&mut self.stopped);
+        // Resolve pending `OpenPath` futures: a path that never finished
+        // validation cannot be established anymore, which semantically equals
+        // `ValidationFailed` (see the `PathEvent::Abandoned` handling in
+        // `forward_app_events`). Without this the futures would never
+        // resolve, keeping the connection state alive through their
+        // `ConnectionRef`s.
+        for (_, sender) in self.open_path.drain() {
+            sender.send_modify(|value| *value = Err(PathError::ValidationFailed));
+        }
         shared.closed.notify_waiters();
         // Send to the registered on_closed futures.
         if !self.on_closed.is_empty() {

--- a/noq/src/tests.rs
+++ b/noq/src/tests.rs
@@ -1557,6 +1557,77 @@ async fn close_path() -> TestResult {
     Ok(())
 }
 
+/// A pending [`OpenPath`] must resolve when the connection is closed;
+/// previously it never resolved (the open-path watch senders were not
+/// drained on terminate), keeping the connection state alive through the
+/// future's `ConnectionRef`.
+///
+/// [`OpenPath`]: crate::OpenPath
+#[tokio::test]
+async fn open_path_resolves_on_connection_close() -> TestResult {
+    let _logging = subscribe();
+    let factory = EndpointFactory::new();
+
+    let mut transport_config = TransportConfig::default();
+    transport_config.max_concurrent_multipath_paths(2);
+    let server = factory.endpoint_with_config("server", transport_config);
+    let server_addr = server.local_addr()?;
+
+    let server_task = async move {
+        let conn = server.accept().await.ok_or("closed conn?")?.await?;
+        conn.closed().await;
+        TestResult::Ok(())
+    }
+    .instrument(info_span!("server"));
+
+    let mut transport_config = TransportConfig::default();
+    transport_config.max_concurrent_multipath_paths(2);
+    let client = factory.endpoint_with_config("client", transport_config);
+
+    // A socket that accepts datagrams but never answers: path validation
+    // towards it stays pending forever (no ICMP refusal, no PATH_RESPONSE).
+    let blackhole = std::net::UdpSocket::bind("127.0.0.1:0")?;
+    let blackhole_addr = blackhole.local_addr()?;
+
+    let client_task = async move {
+        let conn = client.connect(server_addr, "localhost")?.await?;
+
+        // Get a pending open: retry until the path id is allocated (right
+        // after the handshake the open may be rejected for missing CIDs).
+        let open = loop {
+            let open = conn.open_path(
+                FourTuple::from_remote(blackhole_addr),
+                PathStatus::Available,
+            );
+            if open.path_id().is_some() {
+                break open;
+            }
+            match open.await {
+                Err(proto::PathError::RemoteCidsExhausted) => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Ok(_) => unreachable!("a blackholed path cannot validate"),
+                Err(err) => Err(err)?,
+            }
+        };
+
+        // Close the connection while the path is still validating; the
+        // pending future must resolve with an error instead of hanging.
+        conn.close(0u32.into(), b"bye");
+        let resolved = tokio::time::timeout(Duration::from_secs(5), open)
+            .await
+            .map_err(|_| "OpenPath did not resolve after connection close")?;
+        assert!(resolved.is_err(), "a blackholed path cannot have validated");
+        TestResult::Ok(())
+    }
+    .instrument(info_span!("client"));
+
+    let (server_res, client_res) = tokio::join!(server_task, client_task);
+    server_res?;
+    client_res?;
+    TestResult::Ok(())
+}
+
 /// After `initiate_nat_traversal_round`, the connection driver should be
 /// woken so that the REACH_OUT frame is sent promptly. Without a wake,
 /// the frame sits pending until a timer or application data triggers


### PR DESCRIPTION
 This was discovered while testing an experimental [Zenoh-over-MPQUIC](https://github.com/mp0rta/ros2-mpquic-demo) demo:
 when the underlying QUIC connection was closed while an additional path was still being validated, the task awaiting `open_path()` never completed, stalling transport shutdown and recovery.
  
## Description

  A pending `OpenPath` future did not resolve when its connection terminated.

  `State::terminate` notified the other waiter classes but left the
  `open_path` watch senders registered. As a result, the future could remain
  pending indefinitely and retain the connection state through its
  `ConnectionRef`.

  This change:

  - drains pending `open_path` senders during connection termination;
  - resolves them with `PathError::ValidationFailed`, matching the existing
    handling of `PathEvent::Abandoned` for paths that have not opened yet;
  - adds a regression test that closes a connection while path validation
    against a blackholed address is pending.

  Related to #684.

  ## Breaking Changes

  None.

  ## Notes & open questions

  The regression test passes on the updated implementation and would time out
  without the termination handling.

  ## Change checklist

  - [x] Self-review.
  - [x] Tests if relevant.
  - [x] All breaking changes documented.
  - [x] This PR was created by a human that thought critically about the
        proposed change and wrote as clear and concise a description as possible.
  - [x] This PR isn't slop and is carefully crafted to have the intended effect.
  - [x] `cargo make` passes locally.