### PR TITLE
test(proto): fix flaky open_path_validation_fails_server_side

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -103,7 +103,7 @@ pub use streams::{
     ShouldTransmit, StreamEvent, Streams, WriteError,
 };
 
-mod timer;
+pub(crate) mod timer;
 use timer::{Timer, TimerTable};
 
 mod transmit_buf;
@@ -453,6 +453,15 @@ impl Connection {
     #[must_use]
     pub fn poll_timeout(&self) -> Option<Instant> {
         self.timers.peek()
+    }
+
+    /// Returns the instant at which `timer` is armed to fire, or `None` if it is not.
+    ///
+    /// `None` covers the timer never having been armed, having fired, and having been
+    /// cancelled.
+    #[cfg(test)]
+    pub(crate) fn timer_pending(&self, timer: Timer) -> Option<Instant> {
+        self.timers.get(timer)
     }
 
     /// Returns application-facing events

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -9,6 +9,7 @@ use assert_matches::assert_matches;
 use testresult::TestResult;
 use tracing::info;
 
+use crate::connection::timer::{PathTimer, Timer};
 use crate::{
     ClientConfig, ConnectionId, ConnectionIdGenerator, Endpoint, EndpointConfig, FourTuple,
     LOCAL_CID_COUNT, NetworkChangeHint, PathId, PathStatus, RandomConnectionIdGenerator,
@@ -451,10 +452,15 @@ fn open_path_validation_fails_server_side() -> TestResult {
 
     info!("manual keep-alive of PathId::ZERO");
     pair.ping_path(Client, PathId::ZERO)?;
+    // Sent here, before the clock moves: `drive_until_timer` advances time before it
+    // drives, so a queued keep-alive would otherwise go out at the deadline itself.
     pair.drive();
 
     info!("advancing time to past client path {path_id} idle");
-    pair.advance_time();
+    pair.drive_until_timer(Client, Timer::PerPath(path_id, PathTimer::PathIdle));
+    // Deliver the abandonment to the server: the timer fires while driving the client, and
+    // the loop drives the server before that packet arrives. Without this step the
+    // `poll(Server)` check below would pass simply because the server never heard about it.
     pair.drive();
 
     // The client gave up first and timed out.

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -20,6 +20,7 @@ use rustls::{
 use tracing::{debug, info, info_span, trace};
 
 use crate::crypto::rustls::{QuicClientConfig, QuicServerConfig, configured_provider};
+use crate::connection::timer::Timer;
 use crate::{
     ClientConfig, ClosePathError, ClosedPath, Connection, ConnectionError, ConnectionEvent,
     ConnectionHandle, ConnectionStats, DatagramEvent, Datagrams, Dir, Duration, EcnCodepoint,
@@ -764,6 +765,40 @@ impl ConnPair {
 
     pub(super) fn poll_timeout(&mut self, side: Side) -> Option<Instant> {
         self.conn_mut(side).poll_timeout()
+    }
+
+    /// Advances virtual time and drives both endpoints until `timer` fires on `side`.
+    ///
+    /// [`Self::drive`] refuses to step past a point where the only timers still pending
+    /// are idle timers (see `Connection::is_idle`), so it cannot be used to reach an idle
+    /// timeout: the timeout is exactly what `is_idle` discounts. This loop keeps stepping
+    /// to each next wakeup until `timer` is no longer armed.
+    ///
+    /// Note that timers fire in `drive_client`/`drive_server`, not in `advance_time`, so
+    /// every step has to drive both endpoints. A timer that is *cancelled* rather than
+    /// fired also ends the loop; callers should still assert on the event they expect, so
+    /// that a cancellation fails loudly instead of passing silently.
+    ///
+    /// Each step advances the clock *before* driving, so packets that must be sent at the
+    /// current time have to be driven out by a preceding [`Self::drive`]; otherwise they
+    /// are queued until after the first step.
+    ///
+    /// Panics if the timer is still armed after 1024 steps.
+    #[track_caller]
+    pub(super) fn drive_until_timer(&mut self, side: Side, timer: Timer) {
+        let mut steps = 0;
+        while self.conn(side).timer_pending(timer).is_some() {
+            // If `timer` is armed, this endpoint has a wakeup scheduled, so the advance
+            // cannot run out of timers.
+            assert!(
+                self.advance_time(),
+                "{timer:?} is armed but no endpoint has a wakeup scheduled"
+            );
+            self.drive_client();
+            self.drive_server();
+            steps += 1;
+            assert!(steps < 1024, "{timer:?} still armed after {steps} steps");
+        }
     }
 
     pub(super) fn poll(&mut self, side: Side) -> Option<Event> {


### PR DESCRIPTION
## Description

We saw `open_path_validation_fails_server_side` fail intermittently in [daily CI on FreeBSD](https://github.com/n0-computer/noq/actions/runs/33142246096), and matheus23 asked me to look into it. The test advanced with a single `advance_time()`, which jumps to the earliest timer pending on *either* endpoint, and assumed that jump lands on the client's 8s path-idle deadline for the blackholed path. It usually does. When the client happens to do a routine key update shortly before that deadline — PN phase exhaustion, which depends on the randomly chosen initial packet number — the server arms `KeyDiscard` at 3x PTO, and that fires about 100ms earlier. The jump lands there instead, `drive()` then stops stepping because `Connection::is_idle` discounts the idle timers that remain, and virtual time never reaches the deadline. The path-idle timer stays armed the whole time and the connection behaves correctly; the single jump in the test is the bug.

The fix, as suggested by matheus23: a `drive_until_timer` helper that steps to each next wakeup and drives both endpoints until the target timer is no longer armed. `drive()` can't reach an idle timeout on its own — `is_idle` discounts exactly the timers a test would be waiting for — so this needs its own loop. The test now calls it instead of `advance_time()`.

## API Changes

None, test changes only.

## Notes & open questions

- I'm an agent posting from my own account (`n0-grookie`), so I left the "created by a human" box below unticked. matheus23 asked for the PR after reviewing the commits.
- Measured on a seeded sweep over `StdRng::seed_from_u64()` driving the same `ConnPair` setup as the test: 82 of 20000 seeds failed before, 0 of 50000 after. Seed-dependent rather than platform-dependent — the same seeds fail on Linux, which is how I measured it. The sweep is scratch code and not in the commit; it can go in behind an `#[ignore]` if a repeatable sweep is worth having.
- `drive_until_timer` panics rather than hangs if the timer is still armed after 1024 steps, and a *cancelled* timer also ends the loop — callers should keep asserting on the event they expect. Both are in the doc comment.
- I went through the other `advance_time()` call sites in `src/tests`. They step to the next scheduled timer and assert on whatever arrives (`multipath.rs:2124` expects `Established`, the `mod.rs:4746` pair checks draining delays), so they don't carry this test's assumption that the jump lands on a specific deadline. Left them as they are.
- No issue linked: it came out of daily CI and the fix was reviewed out of band.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [ ] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
- [x] `cargo make` passes locally.
