### PR TITLE
test(proto): keep test connections on their initial keys

### DIFF
--- a/noq-proto/src/config/transport.rs
+++ b/noq-proto/src/config/transport.rs
@@ -54,6 +54,8 @@ pub struct TransportConfig {
     pub(crate) datagram_send_buffer_size: usize,
     #[cfg(test)]
     pub(crate) deterministic_packet_numbers: bool,
+    #[cfg(test)]
+    pub(crate) initial_key_phase_size: Option<u64>,
 
     pub(crate) congestion_controller_factory: Arc<dyn congestion::ControllerFactory + Send + Sync>,
 
@@ -332,6 +334,23 @@ impl TransportConfig {
         self
     }
 
+    /// Override the size of the first 1-RTT key phase
+    ///
+    /// A fresh connection picks a short key phase at random (10..1000 packets) so that peers
+    /// which mishandle key updates fail early. That makes the first autonomous key update land
+    /// wherever the seed likes, which is a liability in tests that merely happen to run long
+    /// enough: it arms a `KeyDiscard` timer ahead of the deadline they are waiting for. Set this
+    /// to a size the test will never reach to keep the connection on its initial keys; peer
+    /// initiated and forced updates are unaffected, and the AEAD confidentiality limit still
+    /// applies.
+    ///
+    /// Defaults to `None`, i.e. the random production behavior.
+    #[cfg(test)]
+    pub(crate) fn initial_key_phase_size(&mut self, packets: Option<u64>) -> &mut Self {
+        self.initial_key_phase_size = packets;
+        self
+    }
+
     /// How to construct new `congestion::Controller`s
     ///
     /// Typically the refcounted configuration of a `congestion::Controller`,
@@ -582,6 +601,8 @@ impl Default for TransportConfig {
             datagram_send_buffer_size: 1024 * 1024,
             #[cfg(test)]
             deterministic_packet_numbers: false,
+            #[cfg(test)]
+            initial_key_phase_size: None,
 
             congestion_controller_factory: Arc::new(congestion::CubicConfig::default()),
 
@@ -631,6 +652,8 @@ impl fmt::Debug for TransportConfig {
             datagram_send_buffer_size,
             #[cfg(test)]
                 deterministic_packet_numbers: _,
+            #[cfg(test)]
+                initial_key_phase_size: _,
             congestion_controller_factory: _,
             enable_segmentation_offload,
             address_discovery_role,

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -360,9 +360,13 @@ impl Connection {
             ),
         )]);
 
+        let crypto_state = CryptoState::new(crypto, init_cid, side, &mut rng);
+        #[cfg(test)]
+        let crypto_state = crypto_state.with_key_phase_size(config.initial_key_phase_size);
+
         let mut this = Self {
             endpoint_config,
-            crypto_state: CryptoState::new(crypto, init_cid, side, &mut rng),
+            crypto_state,
             handshake_cid: local_cid,
             remote_handshake_cid: remote_cid,
             local_cid_state,
@@ -6817,6 +6821,12 @@ impl Connection {
             .ok()?;
 
         Some(packet.payload.to_vec())
+    }
+
+    /// How many 1-RTT packets may still be sent before the keys are updated
+    #[cfg(test)]
+    pub(crate) fn key_phase_size(&self) -> u64 {
+        self.crypto_state.key_phase_size
     }
 
     /// The number of bytes of packets containing retransmittable frames that have not been

--- a/noq-proto/src/connection/packet_crypto.rs
+++ b/noq-proto/src/connection/packet_crypto.rs
@@ -137,6 +137,17 @@ impl CryptoState {
         }
     }
 
+    /// Override how many packets the first key phase lasts
+    ///
+    /// See `TransportConfig::initial_key_phase_size`.
+    #[cfg(test)]
+    pub(super) fn with_key_phase_size(mut self, packets: Option<u64>) -> Self {
+        if let Some(packets) = packets {
+            self.key_phase_size = packets;
+        }
+        self
+    }
+
     /// Removes header protection of a packet, or returns `None` if the packet was dropped.
     pub(super) fn unprotect_header(
         &self,

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -1196,6 +1196,25 @@ fn streams_blocked_not_sent_under_limit() {
     );
 }
 
+/// A built pair holds a connection's initial keys unless the test says otherwise
+///
+/// Production starts a connection with a short key phase (10..1000 packets) so that peers which
+/// mishandle key updates fail early. That puts the first autonomous update at an unpredictable
+/// point, so `ConnPairBuilder` pins it out of reach; see `ConnPairBuilder::with_key_update`.
+#[test]
+fn connpair_initial_key_phase_is_pinned() {
+    let pair = ConnPair::builder().connect();
+    assert_eq!(pair.conn(Client).key_phase_size(), u64::MAX);
+    assert_eq!(pair.conn(Server).key_phase_size(), u64::MAX);
+
+    let pair = ConnPair::builder().with_key_update().connect();
+    let size = pair.conn(Client).key_phase_size();
+    assert!(
+        (10..1000).contains(&size),
+        "opted into key updates, expected a short initial phase, got {size}"
+    );
+}
+
 #[test]
 fn key_update_simple() {
     let _guard = subscribe();

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -521,6 +521,7 @@ pub(super) struct ConnPairBuilder {
     pub(super) client_endpoint_cfg: EndpointConfig,
     server_cfg: Option<ServerConfig>,
     routes: Option<Routing>,
+    key_updates: bool,
 }
 
 impl Default for ConnPairBuilder {
@@ -542,6 +543,7 @@ impl Default for ConnPairBuilder {
             client_endpoint_cfg: Default::default(),
             server_cfg: None,
             routes: None,
+            key_updates: false,
         }
     }
 }
@@ -563,6 +565,17 @@ impl ConnPairBuilder {
     pub(super) fn with_transport_cfg(mut self, cfg: TransportConfig) -> Self {
         self.server_transport_cfg = cfg.clone();
         self.client_transport_cfg = cfg;
+        self
+    }
+
+    /// Let the connection update its keys on its own, as it pleases.
+    ///
+    /// By default a built pair pins the first key phase out of reach, so that a test cannot be
+    /// interrupted by an autonomous key update it never asked for. Tests about key updates
+    /// themselves, or about what an update does to timers and paths, should call this. Peer
+    /// initiated and forced updates (`Self::force_key_update`) work either way.
+    pub(super) fn with_key_update(mut self) -> Self {
+        self.key_updates = true;
         self
     }
 
@@ -619,13 +632,22 @@ impl ConnPairBuilder {
         let Self {
             latency,
             mtu,
-            server_transport_cfg,
-            client_transport_cfg,
+            mut server_transport_cfg,
+            mut client_transport_cfg,
             server_endpoint_cfg,
             client_endpoint_cfg,
             server_cfg,
             routes,
+            key_updates,
         } = self;
+
+        // Tests that are not about key updates should not be subject to one: a fresh connection
+        // picks a short key phase at random, so the first autonomous update lands wherever the
+        // seed likes. Opt back in with `Self::with_key_update`.
+        if !key_updates {
+            client_transport_cfg.initial_key_phase_size(Some(u64::MAX));
+            server_transport_cfg.initial_key_phase_size(Some(u64::MAX));
+        }
 
         let server_cfg = server_cfg.unwrap_or(ServerConfig {
             transport: Arc::new(server_transport_cfg),


### PR DESCRIPTION
## Description

Every connection starts with a short first key phase — 10..1000 packets, drawn at random in `CryptoState::new` — so that peers which mishandle key updates fail early. In a test that is not about key updates, that is an unscheduled event with consequences: it arms a `KeyDiscard` timer shortly afterwards, at a point the test cannot predict. That is what made `tests::multipath::open_path_validation_fails_server_side` fail intermittently in the daily CI runs, which #797 fixes for that one test.

flub suggested in that review that the harness should not be subject to key updates at all, and matheus23 agreed it should be its own PR. `ConnPairBuilder` now sets `TransportConfig::initial_key_phase_size` to a size no test reaches, so a built pair stays on its initial keys, with `with_key_update()` to opt back in. `Pair::seeded()` is left alone, so the proptests keep exercising the autonomous update.

## API Changes

None, test changes only. The knob is a `#[cfg(test)]` field on `TransportConfig`, alongside `deterministic_packet_numbers`.

## Notes & open questions

- Written by `n0-grookie`, the agent account, from the review thread on #797. `cargo make` green locally.
- On the pre-#797 sequence over 3000 seeds: 0 failures with the new default, 9 with `with_key_update()`.
- Whether the older harness (`Pair::default()` / `Pair::new()`, ~100 call sites) should get the same default. Those tests build their own `TransportConfig`, so they keep production behaviour.
- No issue linked: the flake came out of the daily CI run and is discussed on #797.

## Change checklist

- [x] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [ ] All API changes documented.
- [ ] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to have the intended effect.
- [x] `cargo make` passes locally.
